### PR TITLE
depjobevents have depjobids, not batchjobids

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -147,7 +147,7 @@ type BatchJob struct {
 type DepJob struct {
 	ID     int           `gorm:"primary_key" json:"-"`
 	DepId  string        `json:"-" validate:"nonzero"`
-	Events []DepJobEvent `json:"events" gorm:"ForeignKey:BatchJobId"`
+	Events []DepJobEvent `json:"events" gorm:"ForeignKey:DepJobId"`
 }
 
 func (b *BatchJob) Status() string {


### PR DESCRIPTION
Without this deployments have broken events, so events can't be preloaded and deployments generally break.