### PR TITLE
uuid primary keys

### DIFF
--- a/EB/.elasticbeanstalk/saved_configs/production.cfg.yml
+++ b/EB/.elasticbeanstalk/saved_configs/production.cfg.yml
@@ -16,7 +16,7 @@ OptionSettings:
     RollingUpdateEnabled: true
     RollingUpdateType: Health
   aws:elasticbeanstalk:application:environment:
-    DATABASE_URL: host=production-api-db.ct01qahxv3zv.us-east-1.rds.amazonaws.com
+    DATABASE_URL: host=production-api-db.ct01qahxv3zv.us-east-1.rds.amazonaws.com user=postgres
       dbname=postgres sslmode=disable password=8c4509bc-1952-11e7-ac62-843a4b0da254
     GIN_MODE: release
     PORT: '8080'

--- a/EB/.elasticbeanstalk/saved_configs/production.cfg.yml
+++ b/EB/.elasticbeanstalk/saved_configs/production.cfg.yml
@@ -16,7 +16,7 @@ OptionSettings:
     RollingUpdateEnabled: true
     RollingUpdateType: Health
   aws:elasticbeanstalk:application:environment:
-    DATABASE_URL: host=test-api-db.ct01qahxv3zv.us-east-1.rds.amazonaws.com user=postgres
+    DATABASE_URL: host=production-api-db.ct01qahxv3zv.us-east-1.rds.amazonaws.com
       dbname=postgres sslmode=disable password=8c4509bc-1952-11e7-ac62-843a4b0da254
     GIN_MODE: release
     PORT: '8080'

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-	"strconv"
 
 	"github.com/ReconfigureIO/platform/service/aws"
 	"github.com/ReconfigureIO/platform/service/mock_deployment"
@@ -48,10 +47,10 @@ func Transaction(c *gin.Context, ops func(db *gorm.DB) error) error {
 	return err
 }
 
-func bindID(c *gin.Context, id *int) bool {
+func bindID(c *gin.Context, id *string) bool {
 	paramID := c.Param("id")
-	if i, err := strconv.Atoi(paramID); err == nil && paramID != "" {
-		*id = i
+	if paramID != "" {
+		*id = paramID
 		return true
 	}
 	sugar.ErrResponse(c, 404, nil)

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -27,11 +27,11 @@ func (d Deployment) Query(c *gin.Context) *gorm.DB {
 // ByID gets the first deployment by ID, 404 if it doesn't exist.
 func (d Deployment) ByID(c *gin.Context) (models.Deployment, error) {
 	dep := models.Deployment{}
-	var id int
+	var id string
 	if !bindID(c, &id) {
 		return dep, errNotFound
 	}
-	err := d.Query(c).First(&dep, id).Error
+	err := d.Query(c).First(&dep, "deployments.id = ?", id).Error
 
 	if err != nil {
 		sugar.NotFoundOrError(c, err)
@@ -51,7 +51,7 @@ func (d Deployment) Create(c *gin.Context) {
 
 	// Ensure that the project exists, and the user has permissions for it
 	build := models.Build{}
-	err := Build{}.Query(c).First(&build, post.BuildID).Error
+	err := Build{}.Query(c).First(&build, "builds.id = ?", post.BuildID).Error
 	if err != nil {
 		sugar.NotFoundOrError(c, err)
 		return
@@ -187,11 +187,11 @@ func addEvent(DepJob *models.DepJob, event models.PostDepEvent) (models.DepJobEv
 
 func (d Deployment) unauthOne(c *gin.Context) (models.Deployment, error) {
 	dep := models.Deployment{}
-	var id int
+	var id string
 	if !bindID(c, &id) {
 		return dep, errNotFound
 	}
 	q := db.Preload("DepJob").Preload("DepJob.Events")
-	err := q.First(&dep, id).Error
+	err := q.First(&dep, "deployments.id = ?", id).Error
 	return dep, err
 }

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/ReconfigureIO/platform/auth"
@@ -88,8 +87,8 @@ func (d Deployment) List(c *gin.Context) {
 	deployments := []models.Deployment{}
 	q := d.Query(c)
 
-	if id, err := strconv.Atoi(build); err == nil && build != "" {
-		q = q.Where(&models.Deployment{BuildID: id})
+	if build != "" {
+		q = q.Where(&models.Deployment{BuildID: build})
 	}
 	err := q.Find(&deployments).Error
 

--- a/api/deployment.go
+++ b/api/deployment.go
@@ -117,7 +117,7 @@ func (d Deployment) Logs(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	StreamDeploymentLogs(mockDeploy, c, &targetdep)
+	streamDeploymentLogs(mockDeploy, c, &targetdep)
 }
 
 func (d Deployment) canPostEvent(c *gin.Context, dep models.Deployment) bool {

--- a/api/logStream.go
+++ b/api/logStream.go
@@ -89,7 +89,7 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 	stream.Start(ctx, lstream, c, awsSession.Conf().LogGroup)
 }
 
-func StreamDeploymentLogs(service *mock_deployment.Service, c *gin.Context, deployment *models.Deployment) {
+func streamDeploymentLogs(service *mock_deployment.Service, c *gin.Context, deployment *models.Deployment) {
 	ctx, cancel := context.WithCancel(c)
 	defer cancel()
 

--- a/api/project.go
+++ b/api/project.go
@@ -47,7 +47,9 @@ func (p Project) Create(c *gin.Context) {
 	}
 	user := auth.GetUser(c)
 	newProject := models.Project{UserID: user.ID, Name: post.Name}
-	db.Create(&newProject)
+	if err := db.Create(&newProject).Error; err != nil {
+		sugar.ErrResponse(c, 500, err)
+	}
 	sugar.SuccessResponse(c, 201, newProject)
 }
 

--- a/api/project.go
+++ b/api/project.go
@@ -25,11 +25,11 @@ func (p Project) Query(c *gin.Context) *gorm.DB {
 // ByID get the first build by ID, 404 if it doesn't exist
 func (p Project) ByID(c *gin.Context) (models.Project, error) {
 	project := models.Project{}
-	var id int
+	var id string
 	if !bindID(c, &id) {
 		return project, errNotFound
 	}
-	err := p.Query(c).First(&project, id).Error
+	err := p.Query(c).First(&project, "projects.id = ?", id).Error
 
 	if err != nil {
 		sugar.NotFoundOrError(c, err)

--- a/api/simulation.go
+++ b/api/simulation.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/ReconfigureIO/platform/auth"
 	"github.com/ReconfigureIO/platform/models"
@@ -131,8 +130,8 @@ func (s Simulation) List(c *gin.Context) {
 	simulations := []models.Simulation{}
 	q := s.Query(c)
 
-	if id, err := strconv.Atoi(project); err == nil && project != "" {
-		q = q.Where(&models.Simulation{ProjectID: id})
+	if project != "" {
+		q = q.Where(&models.Simulation{ProjectID: project})
 	}
 
 	err := q.Find(&simulations).Error

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -21,7 +21,7 @@ func TestProjValidation(t *testing.T) {
 
 func TestDepJobEventValidation(t *testing.T) {
 	newDepJobEvent := models.DepJobEvent{
-		DepJobID: 1,
+		DepJobID: "1",
 	}
 
 	err := validator.Validate(newDepJobEvent)

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -23,7 +23,7 @@ func SessionAuth(db *gorm.DB) gin.HandlerFunc {
 		userID := session.Get(strUserID)
 		if userID != nil {
 			user := models.User{}
-			err := db.First(&user, userID.(int)).Error
+			err := db.First(&user, "id = ?", userID).Error
 			if err != nil && err != gorm.ErrRecordNotFound {
 				c.AbortWithError(500, err)
 				return

--- a/auth/signup.go
+++ b/auth/signup.go
@@ -37,6 +37,10 @@ func (s *signupUser) ResignIn(c *gin.Context) {
 
 func (s *signupUser) SignUp(c *gin.Context) {
 	token := c.Param("token")
+	if token == "" {
+		sugar.ErrResponse(c, 400, "invite token required")
+		return
+	}
 	invite, err := s.GetAuthToken(token)
 	if err != nil {
 		sugar.NotFoundOrError(c, err)

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: a98948d3db3a9f749ed4e3a93a2273c15ea516e2b83f0b8852d5242b887dae6b
-updated: 2017-04-17T22:12:42.591036267Z
+hash: 422e772435a65c25b835dd31b361c38a48ee5e73fc91e8b603fee9ad2819c8af
+updated: 2017-05-15T20:56:37.541370994+01:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 7be45195c3af1b54a609812f90c05a7e492e2491
+  version: cea091b5b8fe6fcecf0eb6ec8f1a2570ff4ee6a7
   subpackages:
   - aws
   - aws/awserr
@@ -21,6 +21,7 @@ imports:
   - aws/session
   - aws/signer/v4
   - private/protocol
+  - private/protocol/ec2query
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
   - private/protocol/query
@@ -31,14 +32,15 @@ imports:
   - private/protocol/xml/xmlutil
   - service/batch
   - service/cloudwatchlogs
+  - service/ec2
   - service/s3
   - service/sts
 - name: github.com/boj/redistore
-  version: 3f631e1df8711f449f7b1796f5b8b7716e4319d0
+  version: 4562487a4bee9a7c272b72bfaeda4917d0a47ab9
 - name: github.com/dchest/uniuri
   version: 8902c56451e9b58ff940bbe5fec35d5f9c04584a
 - name: github.com/garyburd/redigo
-  version: 0d253a66e6e1349f4581d6d2b300ee434ee2da9f
+  version: 433969511232c397de61b1442f9fd49ec06ae9ba
   subpackages:
   - internal
   - redis
@@ -52,7 +54,7 @@ imports:
   - binding
   - render
 - name: github.com/go-ini/ini
-  version: 1730955e3146956d6a087861380f9b4667ed5071
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
@@ -62,7 +64,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: de33c46a823d3f723514fc5333b75ef2e937b7df
+  version: 11516601ad905b8307923d093a487b6a5446f2c4
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -74,9 +76,9 @@ imports:
 - name: github.com/gorilla/securecookie
   version: e59506cc896acb7f7bf732d4fdf5e25f7ccd8983
 - name: github.com/gorilla/sessions
-  version: ba78acc856fe7c79891d516131b3d903cc8d9367
+  version: 8b6b4cd75f07f7ee036eb37b8127bd40ab1efc49
 - name: github.com/jinzhu/gorm
-  version: 572d0a0ab1eb75410a2729e96239152d1da7a91f
+  version: 45ccb134373e7d9fa76d5987a6fed6cd5a5adfd4
   subpackages:
   - dialects/postgres
 - name: github.com/jinzhu/inflection
@@ -84,7 +86,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/lib/pq
-  version: 472a0745531a17dbac346e828b4c60e73ddff30c
+  version: 2704adc878c21e1329f46f6e56a1c387d788ff94
   subpackages:
   - hstore
   - oid
@@ -92,17 +94,19 @@ imports:
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/mattn/go-isatty
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: golang.org/x/net
   version: f315505cf3349909cdf013ea56690da34e96a451
   subpackages:
   - context
 - name: golang.org/x/oauth2
-  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  version: ad516a297a9f2a74ecc244861b298c94bdd28b9d
   subpackages:
   - github
   - internal
 - name: golang.org/x/sys
-  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  version: f3918c30c5c2cb527c0b071a27c35120a6c0719a
   subpackages:
   - unix
 - name: google.golang.org/appengine
@@ -122,5 +126,5 @@ imports:
 - name: gopkg.in/validator.v2
   version: 0a9835d809fb647a62611d30cb792e0b5dd65b11
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 422e772435a65c25b835dd31b361c38a48ee5e73fc91e8b603fee9ad2819c8af
-updated: 2017-05-15T20:56:37.541370994+01:00
+hash: 160b4fde86558364c8f36cc05680eccd58947e1b8e1fab6476fe702ee6c145b2
+updated: 2017-05-18T10:07:28.238510036+01:00
 imports:
+- name: github.com/abiosoft/errs
+  version: 42b3fcff7074a30e8c369806679bd0e983326bd4
 - name: github.com/aws/aws-sdk-go
-  version: cea091b5b8fe6fcecf0eb6ec8f1a2570ff4ee6a7
+  version: 3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c
   subpackages:
   - aws
   - aws/awserr
@@ -64,7 +66,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: 11516601ad905b8307923d093a487b6a5446f2c4
+  version: 4b7b445665c8ce4f3c10c753b1884e2c4f09e323
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -101,7 +103,7 @@ imports:
   subpackages:
   - context
 - name: golang.org/x/oauth2
-  version: ad516a297a9f2a74ecc244861b298c94bdd28b9d
+  version: f047394b6d14284165300fd82dad67edb3a4d7f6
   subpackages:
   - github
   - internal

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,3 +17,5 @@ import:
 - package: github.com/golang/mock
   subpackages:
   - gomock
+- package: github.com/satori/go.uuid
+  version: ~1.1.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,3 +19,4 @@ import:
   - gomock
 - package: github.com/satori/go.uuid
   version: ~1.1.0
+- package: github.com/abiosoft/errs

--- a/models/models.go
+++ b/models/models.go
@@ -63,7 +63,7 @@ type Build struct {
 	uuidHook
 	ID          string       `gorm:"primary_key" json:"id"`
 	Project     Project      `json:"project" gorm:"ForeignKey:ProjectID"`
-	ProjectID   int          `json:"-"`
+	ProjectID   string       `json:"-"`
 	BatchJob    BatchJob     `json:"job" gorm:"ForeignKey:BatchJobId"`
 	BatchJobID  int64        `json:"-"`
 	Token       string       `json:"-"`
@@ -184,6 +184,7 @@ type BatchJob struct {
 
 // DepJob model.
 type DepJob struct {
+	uuidHook
 	ID     string        `gorm:"primary_key" json:"-"`
 	DepID  string        `json:"-" validate:"nonzero"`
 	Events []DepJobEvent `json:"events" gorm:"ForeignKey:DepJobId"`

--- a/models/models.go
+++ b/models/models.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/dchest/uniuri"
+	"github.com/jinzhu/gorm"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (
@@ -21,9 +23,17 @@ const (
 	StatusErrored = "ERRORED"
 )
 
+// uuidHook hooks new uuid as primary key for models before creation.
+type uuidHook struct{}
+
+func (u uuidHook) BeforeCreate(scope *gorm.Scope) error {
+	return scope.SetColumn("id", uuid.NewV4().String())
+}
+
 // User model.
 type User struct {
-	ID                int    `gorm:"primary_key" json:"id"`
+	uuidHook
+	ID                string `gorm:"primary_key" json:"id"`
 	GithubID          int    `gorm:"unique_index" json:"-"`
 	GithubName        string `json:"github_name"`
 	Name              string `json:"name"`
@@ -39,9 +49,10 @@ func NewUser() User {
 
 // Project model.
 type Project struct {
-	ID          int     `gorm:"primary_key" json:"id"`
+	uuidHook
+	ID          string  `gorm:"primary_key" json:"id"`
 	User        User    `json:"-" gorm:"ForeignKey:UserID"` //Project belongs to User
-	UserID      int     `json:"-"`
+	UserID      string  `json:"-"`
 	Name        string  `json:"name"`
 	Builds      []Build `json:"builds,omitempty" gorm:"ForeignKey:ProjectID"`
 	Simulations []Build `json:"simulations,omitempty" gorm:"ForeignKey:ProjectID"`
@@ -49,7 +60,8 @@ type Project struct {
 
 // Build model.
 type Build struct {
-	ID          int          `gorm:"primary_key" json:"id"`
+	uuidHook
+	ID          string       `gorm:"primary_key" json:"id"`
 	Project     Project      `json:"project" gorm:"ForeignKey:ProjectID"`
 	ProjectID   int          `json:"-"`
 	BatchJob    BatchJob     `json:"job" gorm:"ForeignKey:BatchJobId"`
@@ -94,16 +106,17 @@ func (b *Build) HasFinished() bool {
 
 // PostBuild is post request body for a new build.
 type PostBuild struct {
-	ProjectID int `json:"project_id" validate:"nonzero"`
+	ProjectID string `json:"project_id" validate:"nonzero"`
 }
 
 // Simulation model.
 type Simulation struct {
-	ID         int      `gorm:"primary_key" json:"id"`
+	uuidHook
+	ID         string   `gorm:"primary_key" json:"id"`
 	User       User     `json:"-" gorm:"ForeignKey:UserID"`
 	UserID     int      `json:"-"`
 	Project    Project  `json:"project,omitempty" gorm:"ForeignKey:ProjectID"`
-	ProjectID  int      `json:"-"`
+	ProjectID  string   `json:"-"`
 	BatchJobID int64    `json:"-"`
 	BatchJob   BatchJob `json:"job" gorm:"ForeignKey:BatchJobId"`
 	Token      string   `json:"-"`
@@ -122,24 +135,25 @@ func (s *Simulation) Status() string {
 
 // PostSimulation is the post request body for new simulation.
 type PostSimulation struct {
-	ProjectID int    `json:"project_id" validate:"nonzero"`
+	ProjectID string `json:"project_id" validate:"nonzero"`
 	Command   string `json:"command" validate:"nonzero"`
 }
 
 // Deployment model.
 type Deployment struct {
-	ID       int    `gorm:"primary_key" json:"id"`
+	uuidHook
+	ID       string `gorm:"primary_key" json:"id"`
 	Build    Build  `json:"build" gorm:"ForeignKey:BuildID"`
-	BuildID  int    `json:"-"`
+	BuildID  string `json:"-"`
 	Command  string `json:"command"`
 	Token    string `json:"-"`
-	DepJobID int    `json:"-"`
+	DepJobID string `json:"-"`
 	DepJob   DepJob `json:"job,omitempty" gorm:"ForeignKey:DepJobId"`
 }
 
 // PostDeployment is post request body for new deployment.
 type PostDeployment struct {
-	BuildID int    `json:"build_id" validate:"nonzero"`
+	BuildID string `json:"build_id" validate:"nonzero"`
 	Command string `json:"command" validate:"nonzero"`
 }
 
@@ -170,7 +184,7 @@ type BatchJob struct {
 
 // DepJob model.
 type DepJob struct {
-	ID     int           `gorm:"primary_key" json:"-"`
+	ID     string        `gorm:"primary_key" json:"-"`
 	DepID  string        `json:"-" validate:"nonzero"`
 	Events []DepJobEvent `json:"events" gorm:"ForeignKey:DepJobId"`
 }
@@ -207,7 +221,8 @@ func (d *DepJob) Status() string {
 
 // BatchJobEvent model.
 type BatchJobEvent struct {
-	ID         int64     `gorm:"primary_key" json:"-"`
+	uuidHook
+	ID         string    `gorm:"primary_key" json:"-"`
 	BatchJobID int64     `json:"-"`
 	Timestamp  time.Time `json:"timestamp"`
 	Status     string    `json:"status"`
@@ -227,8 +242,9 @@ func (d *DepJob) HasFinished() bool {
 
 // DepJobEvent model.
 type DepJobEvent struct {
-	ID        int       `gorm:"primary_key" json:"-"`
-	DepJobID  int       `json:"-" validate:"nonzero"`
+	uuidHook
+	ID        string    `gorm:"primary_key" json:"-"`
+	DepJobID  string    `json:"-" validate:"nonzero"`
 	Timestamp time.Time `json:"timestamp"`
 	Status    string    `json:"status"`
 	Message   string    `json:"message,omitempty"`

--- a/service/aws/aws.go
+++ b/service/aws/aws.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"errors"
 	"io"
-	"time"
-
 	"io/ioutil"
-
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/service/mock_deployment/mock_deployment.go
+++ b/service/mock_deployment/mock_deployment.go
@@ -98,7 +98,7 @@ func (s *Service) GetDepDetail(id int) (string, error) {
 	return "imaginary", nil
 }
 
-func (s *Service) GetJobStream(id int) (string, error) {
+func (s *Service) GetJobStream(id string) (string, error) {
 
 	return "doing doing deployed", nil
 }

--- a/service/mock_deployment/mock_deployment.go
+++ b/service/mock_deployment/mock_deployment.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/ReconfigureIO/platform/models"
-	awsService "github.com/ReconfigureIO/platform/service/aws"
+	awsservice "github.com/ReconfigureIO/platform/service/aws"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
@@ -122,7 +122,7 @@ func (s *Service) GetDeploymentStream(ctx context.Context, deployment models.Dep
 	}
 
 	if len(resp.LogStreams) == 0 {
-		return nil, awsService.ErrNotFound
+		return nil, awsservice.ErrNotFound
 	}
 	return resp.LogStreams[0], nil
 


### PR DESCRIPTION
switch users, builds, simulations, deployments to use string instead of int as primary keys.
add a `beforeCreate` hook to the models to generate new uuid as `id`.
