### PR TITLE
don't set a user if we get a not found from the db.

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -28,7 +28,9 @@ func SessionAuth(db *gorm.DB) gin.HandlerFunc {
 				c.AbortWithError(500, err)
 				return
 			}
-			c.Set(strUser, user)
+			if err != gorm.ErrRecordNotFound {
+				c.Set(strUser, user)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should fix the `gh_0_` issues. 