### PR TITLE
Disable open signups.

### DIFF
--- a/handlers/auth/signup.go
+++ b/handlers/auth/signup.go
@@ -132,9 +132,9 @@ func (s *SignupUser) Callback(c *gin.Context) {
 		return
 	}
 
-	user, err := s.GH.GetOrCreateUser(c, token.AccessToken)
+	user, err := s.GH.GetOrCreateUser(c, token.AccessToken, newUser)
 	if err != nil {
-		c.Error(err)
+		sugar.NotFoundOrError(c, err)
 		return
 	}
 


### PR DESCRIPTION
A refactor got rid of checking whether a valid token existed or
not. This adds it back in, as well as error handling.