### PR TITLE
switch to logger that tries to re-establish connection

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/bshuster-repo/logruzio"
+	"github.com/ReconfigureIO/logruzio"
 	"github.com/sirupsen/logrus"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: faf509e76a23697b6cc8d4acc6671c4de1a1a0b7dc89d30aff5f9a9b736de0a3
-updated: 2017-11-13T16:37:52.77195709Z
+hash: d38fe0576eaac20629b19c6a51995baa9145fc104bee0df8e96e2f6ec0ba77d5
+updated: 2018-01-10T16:18:16.232237969Z
 imports:
 - name: github.com/abiosoft/errs
   version: db634b8eb5e35ffff64e0bfe982c1a72a6ecdf3d
 - name: github.com/aws/aws-sdk-go
-  version: e6c5e190452424b404ecdb81d6e3991d46b18e9d
+  version: 3c754f1d340244540350f0a00b940781bae9c905
   subpackages:
   - aws
   - aws/awserr
@@ -40,14 +40,14 @@ imports:
   - service/sts
 - name: github.com/boj/redistore
   version: 4562487a4bee9a7c272b72bfaeda4917d0a47ab9
-- name: github.com/bshuster-repo/logruzio
-  version: b0b294934396cec7a3292f694193f73cb9ddd71f
 - name: github.com/caarlos0/env
-  version: 9de094f90fa8a13dc162e10ae8a3b95c0c2c33e1
+  version: 7cd7992b3bc86f920394f8de92c13900da1a46b7
+- name: github.com/cenkalti/backoff
+  version: 2ea60e5f094469f9e65adb9cd103795b73ae743e
 - name: github.com/dchest/uniuri
   version: 8902c56451e9b58ff940bbe5fec35d5f9c04584a
 - name: github.com/garyburd/redigo
-  version: 47dc60e71eed504e3ef8e77ee3c6fe720f3be57f
+  version: d1ed5c67e5794de818ea85e6b522fda02623a484
   subpackages:
   - internal
   - redis
@@ -56,28 +56,28 @@ imports:
 - name: github.com/gin-contrib/sse
   version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
 - name: github.com/gin-gonic/contrib
-  version: 8f08bc9b92a9734916abda03656c5f1b99ad10be
+  version: 88aede40372d4bcb11e45168a8c30d99e44cf617
   subpackages:
   - ginrus
   - sessions
 - name: github.com/gin-gonic/gin
-  version: ae9f03e6e80212e45427f811683f2a512cc8f506
+  version: a712f77d7aaec7eb4766a663924aaa4e54d3fe70
   subpackages:
   - binding
   - json
   - render
 - name: github.com/go-ini/ini
-  version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
+  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
 - name: github.com/golang/mock
-  version: 61503c535dc549c7ffc1ff07902345658a0f20a2
+  version: b3e60bcdc577185fce3cf625fc96b62857ce5574
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
   subpackages:
   - proto
 - name: github.com/google/go-github
-  version: 8c08f4fba5e05e0fd2821a5f80cf0cf643bd5314
+  version: c988f775700b9ab14b5acb7502046fa341daf82d
   subpackages:
   - github
 - name: github.com/google/go-querystring
@@ -99,24 +99,26 @@ imports:
 - name: github.com/jinzhu/inflection
   version: 1c35d901db3da928c72a72d8458480cc9ade058f
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b
 - name: github.com/json-iterator/go
-  version: 9fddff05f0b5cfe038f1802add248f3f0d08a015
+  version: c3ed5e85e01b662dce06b590ba4262266acbc73a
 - name: github.com/lib/pq
-  version: 8c6ee72f3e6bcb1542298dd5f76cb74af9742cec
+  version: 83612a56d3dd153a94a629cd64925371c9adad78
   subpackages:
   - hstore
   - oid
 - name: github.com/mattn/go-isatty
   version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
+- name: github.com/ReconfigureIO/logruzio
+  version: cd769a9cbdfa4f9d890e88600e87fe868c08e4ac
 - name: github.com/robfig/cron
   version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/cobra
-  version: 2da4a54c5ceefcee7ca5dd0eea1e18a3b6366489
+  version: b95ab734e27d33e0d8fbabf71ca990568d4e2020
 - name: github.com/spf13/pflag
   version: 4c012f6dcd9546820e378d0bdda4d8fc772cdfea
 - name: github.com/stripe/stripe-go
@@ -126,30 +128,30 @@ imports:
   - orderitem
   - sub
 - name: github.com/ugorji/go
-  version: 69968d74aefca74ab12359e8e24e057fb7d88222
+  version: ccfe18359b55b97855cee1d3f74e5efbda4869dc
   subpackages:
   - codec
 - name: golang.org/x/crypto
-  version: 6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd
+  version: b3c9a1d25cfbbbab0ff4780b71c4f54e6e92a0de
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: a337091b0525af65de94df2eb7e98bd9962dcbe2
+  version: 434ec0c7fe3742c984919a691b2018a6e9694425
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/oauth2
-  version: 9ff8ebcc8e241d46f52ecc5bff0e5a2f2dbef402
+  version: 30785a2c434e431ef7c507b54617d6a951d5f2b4
   subpackages:
   - github
   - internal
 - name: golang.org/x/sys
-  version: 1e2299c37cc91a509f1b12369872d27be0ce98a6
+  version: 810d7000345868fc619eb81f46307107118f4ae1
   subpackages:
   - unix
   - windows
 - name: google.golang.org/appengine
-  version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
+  version: 5bee14b453b4c71be47ec1781b0fa61c2ea182db
   subpackages:
   - internal
   - internal/base
@@ -169,5 +171,5 @@ imports:
 - name: gopkg.in/validator.v2
   version: 460c83432a98c35224a6fe352acf8b23e067ad06
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,7 +32,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: ^1.0.2
 - package: gopkg.in/intercom/intercom-go.v2
-- package: github.com/bshuster-repo/logruzio 
+- package: github.com/ReconfigureIO/logruzio 
 - package: github.com/robfig/cron
   version: ^1.0.0
 - package: github.com/spf13/cobra


### PR DESCRIPTION
Type of change
==============

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Description
===========
At the moment the API connects to logz.io on start and keeps it open while running to post logs. Sometimes the unforeseen happens and this connection fails. When that happens the API does not attempt to recreate the connection so we lose logs entirely. 

This PR attempts to fix that by switching to a logger that can retry the connection.
<!--- What does this code solve? How does it solve it? -->

Review Checklist
================

<!--- Don't edit this, the reviewer will. Make sure you follow it though -->

Goals
-----

- [ ] Does it solve the problem?

- [ ] Is it the simplest implementation of that solution?
    Does it yak shave? Does it introduce new dependencies that aren't necessary?

- [ ] Does it decrease modularity?
    Does the user of a module need to import another module to use this one?
    If we want to delete these changes, how easy is that?

- [ ] Does it clarify our domain?
    What things does it refine? What things get added? How does this pave the way for new things?
    Are things named in such a way that a domain expert can find them?

- [ ] Does it introduce non-domain concepts?
    What does the user of this need to learn outside of our domain in order to use this?

Testing
-------

- [ ] Do we integration test changes to external services?

- [ ] Do we unit test code we can change?
