### PR TITLE
if user posts terminating, we should terminate the batch job

### DIFF
--- a/handlers/api/batch.go
+++ b/handlers/api/batch.go
@@ -27,13 +27,13 @@ func (b BatchService) AddEvent(batchJob *models.BatchJob, event models.PostBatch
 	err := repo.AddEvent(*batchJob, newEvent)
 
 	if err != nil {
-		return models.BatchJobEvent{}, nil
+		return models.BatchJobEvent{}, err
 	}
 
-	if newEvent.Status == models.StatusTerminated {
+	if newEvent.Status == models.StatusTerminating {
 		err = awsSession.HaltJob(batchJob.BatchID)
 		if err != nil {
-			return models.BatchJobEvent{}, nil
+			return models.BatchJobEvent{}, err
 		}
 	}
 	return newEvent, nil


### PR DESCRIPTION
Type of change
==============

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

Description
===========
Turns out we were waiting for a user to post a TERMINATED event to a batch job and only then would we halt the job. When a user wants a job to terminate they actually post TERMINATING, so trigger job halt on that code.
<!--- What does this code solve? How does it solve it? -->

Review Checklist
================

<!--- Don't edit this, the reviewer will. Make sure you follow it though -->

Goals
-----

- [ ] Does it solve the problem?

- [ ] Is it the simplest implementation of that solution?
    Does it yak shave? Does it introduce new dependencies that aren't necessary?

- [ ] Does it decrease modularity?
    Does the user of a module need to import another module to use this one?
    If we want to delete these changes, how easy is that?

- [ ] Does it clarify our domain?
    What things does it refine? What things get added? How does this pave the way for new things?
    Are things named in such a way that a domain expert can find them?

- [ ] Does it introduce non-domain concepts?
    What does the user of this need to learn outside of our domain in order to use this?

Testing
-------

- [ ] Do we integration test changes to external services?

- [ ] Do we unit test code we can change?
