### PR TITLE
allow staging dashboard instances to connect to production API

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 		corsConfig.AllowOrigins = []string{
 			"http://app.reconfigure.io",
 			"https://app.reconfigure.io",
+			"https://app.reconfigureio-infra.com",
 			"http://local.reconfigure.io",
 			"http://local.reconfigure.io:4200",
 			"https://reconfigure.io",


### PR DESCRIPTION
Type of change
==============

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

Description
===========
Staging dashboards are on the app.reconfigureio-infra.com domain. Since they should be tested against the production API, this PR allows things on that domain to access the API.

This is blocking: https://github.com/ReconfigureIO/UX/pull/30
<!--- What does this code solve? How does it solve it? -->

Review Checklist
================

<!--- Don't edit this, the reviewer will. Make sure you follow it though -->

Goals
-----

- [x] Does it solve the problem?

- [x] Is it the simplest implementation of that solution?
    Does it yak shave? Does it introduce new dependencies that aren't necessary?

- [x] Does it decrease modularity?
    Does the user of a module need to import another module to use this one?
    If we want to delete these changes, how easy is that?

- [x] Does it clarify our domain?
    What things does it refine? What things get added? How does this pave the way for new things?
    Are things named in such a way that a domain expert can find them?

- [x] Does it introduce non-domain concepts?
    What does the user of this need to learn outside of our domain in order to use this?

Testing
-------

- [x] Do we integration test changes to external services?

- [x] Do we unit test code we can change?
