### PR TITLE
Avoid taking pointers to loop variables

### DIFF
--- a/service/aws/aws.go
+++ b/service/aws/aws.go
@@ -140,9 +140,7 @@ func (s *service) RunSimulation(inputArtifactURL string, callbackURL string, com
 		JobName:       aws.String("example"),            // Required
 		JobQueue:      aws.String(s.conf.Queue),         // Required
 		ContainerOverrides: &batch.ContainerOverrides{
-			Command: []*string{
-				aws.String("/opt/simulate.sh"),
-			},
+			Command: aws.StringSlice([]string{"/opt/simulate.sh"}),
 			Environment: []*batch.KeyValuePair{
 				{
 					Name:  aws.String("PART"),
@@ -192,9 +190,7 @@ func (s *service) RunGraph(graph models.Graph, callbackURL string) (string, erro
 		JobName:       aws.String("example"),            // Required
 		JobQueue:      aws.String(s.conf.Queue),         // Required
 		ContainerOverrides: &batch.ContainerOverrides{
-			Command: []*string{
-				aws.String("/opt/graph.sh"),
-			},
+			Command: aws.StringSlice([]string{"/opt/graph.sh"}),
 			Environment: []*batch.KeyValuePair{
 				{
 					Name:  aws.String("INPUT_URL"),
@@ -234,7 +230,9 @@ func (s *service) RunDeployment(command string) (string, error) {
 
 func (s *service) GetJobDetail(id string) (*batch.JobDetail, error) {
 	batchSession := batch.New(s.session)
-	inp := &batch.DescribeJobsInput{Jobs: []*string{&id}}
+	inp := &batch.DescribeJobsInput{
+		Jobs: aws.StringSlice([]string{id}),
+	}
 	resp, err := batchSession.DescribeJobs(inp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix #227

Type of change
==============

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Description
===========

<!--- What does this code solve? How does it solve it? -->

See issue #227 for detail. Loop variables exist by value, if you take a pointer to them, you only get one pointer.

It raises an interesting question of why this was not caught before, maybe it's a hint that we could use more testing around here.

I assume this has not been hit (edit: noticed) in production because there are in practice not that many of these happening at any one time.

Worth considering what the failure mode is for a moment, it seems possible that this result in corrupt state?

Review Checklist
================

<!--- Don't edit this, the reviewer will. Make sure you follow it though -->

Goals
-----

- [ ] Does it solve the problem?

- [ ] Is it the simplest implementation of that solution?
    Does it yak shave? Does it introduce new dependencies that aren't necessary?

- [ ] Does it decrease modularity?
    Does the user of a module need to import another module to use this one?
    If we want to delete these changes, how easy is that?

- [ ] Does it clarify our domain?
    What things does it refine? What things get added? How does this pave the way for new things?
    Are things named in such a way that a domain expert can find them?

- [ ] Does it introduce non-domain concepts?
    What does the user of this need to learn outside of our domain in order to use this?

Testing
-------

- [ ] Do we integration test changes to external services?

- [ ] Do we unit test code we can change?