### PR TITLE
Revert "Remove redundant http headers from stream requests"

### DIFF
--- a/handlers/api/logStream.go
+++ b/handlers/api/logStream.go
@@ -22,6 +22,12 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 	ctx, cancel := WithClose(c)
 	defer cancel()
 
+	w := c.Writer
+
+	// set necessary headers to inform client of streaming connection
+	w.Header().Set("Connection", "Keep-Alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
@@ -94,6 +100,12 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 func streamDeploymentLogs(service deployment.Service, awsSession aws.Service, c *gin.Context, deployment *models.Deployment) {
 	ctx, cancel := WithClose(c)
 	defer cancel()
+
+	w := c.Writer
+
+	// set necessary headers to inform client of streaming connection
+	w.Header().Set("Connection", "Keep-Alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
 
 	refresh := func() error {
 		return db.Model(&deployment).Association("Events").Find(&deployment.Events).Error


### PR DESCRIPTION
We're currently investigating #243, whereby `reco ... log` is returning too early. Very little has changed recently so we're reverting this change to rule it in/out.

Reverts ReconfigureIO/platform#235