### PR TITLE
Revert "Update glide lockfile (#241)"

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: d38fe0576eaac20629b19c6a51995baa9145fc104bee0df8e96e2f6ec0ba77d5
-updated: 2018-06-20T11:44:22.502718758+01:00
+updated: 2018-01-10T16:18:16.232237969Z
 imports:
 - name: github.com/abiosoft/errs
   version: db634b8eb5e35ffff64e0bfe982c1a72a6ecdf3d
 - name: github.com/aws/aws-sdk-go
-  version: f0bbc646e13bfc451409e960cf33239aabb8671a
+  version: 3c754f1d340244540350f0a00b940781bae9c905
   subpackages:
   - aws
   - aws/awserr
@@ -16,20 +16,15 @@ imports:
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
   - aws/credentials/stscreds
-  - aws/csm
   - aws/defaults
   - aws/ec2metadata
   - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - internal/sdkio
-  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/ec2query
-  - private/protocol/eventstream
-  - private/protocol/eventstream/eventstreamapi
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
   - private/protocol/query
@@ -42,14 +37,11 @@ imports:
   - service/cloudwatchlogs
   - service/ec2
   - service/s3
-  - service/s3/s3iface
-  - service/s3/s3manager
-  - service/s3/s3manager/s3manageriface
   - service/sts
 - name: github.com/boj/redistore
   version: 4562487a4bee9a7c272b72bfaeda4917d0a47ab9
 - name: github.com/caarlos0/env
-  version: 1cddc31c48c56ecd700d873edb9fd5b6f5df922a
+  version: 7cd7992b3bc86f920394f8de92c13900da1a46b7
 - name: github.com/cenkalti/backoff
   version: 2ea60e5f094469f9e65adb9cd103795b73ae743e
 - name: github.com/dchest/uniuri
@@ -120,11 +112,11 @@ imports:
 - name: github.com/ReconfigureIO/logruzio
   version: cd769a9cbdfa4f9d890e88600e87fe868c08e4ac
 - name: github.com/robfig/cron
-  version: b41be1df696709bb6395fe435af20370037c0b4c
+  version: b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
-  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/cobra
   version: b95ab734e27d33e0d8fbabf71ca990568d4e2020
 - name: github.com/spf13/pflag


### PR DESCRIPTION
As part of investigating #243.

This reverts commit 53b47c81244dc68e51972470d4d08de41392d165.