### PR TITLE
Revert "Revert "Remove redundant http headers from stream requests""

### DIFF
--- a/handlers/api/logStream.go
+++ b/handlers/api/logStream.go
@@ -22,12 +22,6 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 	ctx, cancel := WithClose(c)
 	defer cancel()
 
-	w := c.Writer
-
-	// set necessary headers to inform client of streaming connection
-	w.Header().Set("Connection", "Keep-Alive")
-	w.Header().Set("Transfer-Encoding", "chunked")
-
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
@@ -100,12 +94,6 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 func streamDeploymentLogs(service deployment.Service, awsSession aws.Service, c *gin.Context, deployment *models.Deployment) {
 	ctx, cancel := WithClose(c)
 	defer cancel()
-
-	w := c.Writer
-
-	// set necessary headers to inform client of streaming connection
-	w.Header().Set("Connection", "Keep-Alive")
-	w.Header().Set("Transfer-Encoding", "chunked")
 
 	refresh := func() error {
 		return db.Model(&deployment).Association("Events").Find(&deployment.Events).Error


### PR DESCRIPTION
This turns out to not be the root cause, so I'm reverting the reversion to bring it back.

Reverts ReconfigureIO/platform#244.

Once it goes green, I will deploy, and once it's deployed, I will test it again with a reco sim.

See #243.