### PR TITLE
[WIP] Keep glide cache between docker-compose builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,9 @@
 version: '2'
+
+volumes:
+  glide-cache: {}
+
+
 services:
   db:
     image: postgres:alpine
@@ -8,6 +13,7 @@ services:
     working_dir: /go/src/github.com/ReconfigureIO/platform
     volumes:
       - .:/go/src/github.com/ReconfigureIO/platform
+      - glide-cache:/root/.glide
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Glide keeps cache state in `~/.glide`.

At the moment, every time I run a docker-compose command which runs glide, it fetches all of our dependencies. This isn't great, especially on the bad WeWork WiFi.

The fix is to have a separate docker volume which is persistent.

Before this can be merged:

- [x] Consider impact for Jenkins. Do we need to add `--volume` to `docker system prune`?