### PR TITLE
break AWSService interface into smaller pieces (batch, log, etc)

### DIFF
--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/storage"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ReconfigureIO/platform/middleware"
 	"github.com/ReconfigureIO/platform/models"
@@ -222,7 +224,16 @@ func (b Build) Logs(c *gin.Context) {
 		return
 	}
 
-	StreamBatchLogs(b.AWS, c, &build.BatchJob)
+	err = batch.CopyLogs(
+		c,
+		&b.AWS,
+		c.Writer,
+		c.Request,
+		&build.BatchJob,
+	)
+	if err != nil {
+		log.WithError(err).Warnln("batch.CopyLogs error")
+	}
 }
 
 func (b Build) canPostEvent(c *gin.Context, build models.Build) bool {

--- a/handlers/api/deployment.go
+++ b/handlers/api/deployment.go
@@ -30,7 +30,7 @@ type Deployment struct {
 	UseSpotInstances bool
 	Storage          storage.Service
 	DeployService    deployment.Service
-	AWS              aws.Service
+	AWS              *aws.Service
 	PublicProjectID  string
 }
 
@@ -220,7 +220,7 @@ func (d Deployment) Logs(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	streamDeploymentLogs(d.DeployService, d.AWS, c, &targetDep)
+	streamDeploymentLogs(d.DeployService, *d.AWS, c, &targetDep)
 }
 
 func (d Deployment) canPostEvent(c *gin.Context, dep models.Deployment) bool {

--- a/handlers/api/graph.go
+++ b/handlers/api/graph.go
@@ -20,7 +20,7 @@ import (
 type Graph struct {
 	Events  events.EventService
 	Storage storage.Service
-	AWS     aws.Service
+	AWS     *aws.Service
 }
 
 // Common preload functionality.
@@ -147,7 +147,7 @@ func (g Graph) Input(c *gin.Context) {
 	}
 
 	err = Transaction(c, func(tx *gorm.DB) error {
-		batchJob := BatchService{AWS: g.AWS}.New(graphID)
+		batchJob := BatchService{AWS: *g.AWS}.New(graphID)
 		return tx.Model(&graph).Association("BatchJob").Append(batchJob).Error
 	})
 
@@ -238,7 +238,7 @@ func (g Graph) CreateEvent(c *gin.Context) {
 		sugar.ErrResponse(c, 400, fmt.Sprintf("Users cannot post TERMINATED events, please upgrade to reco v0.3.1 or above"))
 	}
 
-	newEvent, err := BatchService{AWS: g.AWS}.AddEvent(&graph.BatchJob, event)
+	newEvent, err := BatchService{AWS: *g.AWS}.AddEvent(&graph.BatchJob, event)
 
 	if err != nil {
 		sugar.InternalError(c, nil)

--- a/handlers/api/simulation_test.go
+++ b/handlers/api/simulation_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/golang/mock/gomock"
 )
 
@@ -11,7 +11,7 @@ func Test_ServiceInterface(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	s := aws.NewMockService(mockCtrl)
+	s := batch.NewMockService(mockCtrl)
 	s.EXPECT().RunSimulation("foo", "bar", "test").Return("foobar", nil)
 	ss, err := s.RunSimulation("foo", "bar", "test")
 	if err != nil || ss != "foobar" {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -23,7 +23,7 @@ func SetupRoutes(
 	secretKey string,
 	r *gin.Engine,
 	db *gorm.DB,
-	awsService aws.Service,
+	awsService *aws.Service,
 	events events.EventService,
 	leads leads.Leads,
 	storage storage.Service,
@@ -75,7 +75,7 @@ func SetupRoutes(
 		Events:          events,
 		Storage:         storage,
 		PublicProjectID: publicProjectID,
-		AWS:             awsService,
+		AWS:             *awsService,
 	}
 	buildRoute := apiRoutes.Group("/builds")
 	{

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/ReconfigureIO/platform/config"
 	"github.com/ReconfigureIO/platform/service/auth"
+	"github.com/ReconfigureIO/platform/service/aws"
 	"github.com/ReconfigureIO/platform/service/events"
+	"github.com/ReconfigureIO/platform/service/fakebatchlogs"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -40,10 +42,12 @@ func TestIndexHandler(t *testing.T) {
 
 	events := events.NewIntercomEventService(icConf, 100)
 
+	awsSession := aws.New(aws.ServiceConfig{}, &fakebatchlogs.Service{})
+
 	// Setup router
 	r := gin.Default()
 	r.LoadHTMLGlob("../templates/*")
-	r = SetupRoutes(config.RecoConfig{}, "secretKey", r, db, nil, events, nil, nil, nil, "foobar", &auth.NOPService{})
+	r = SetupRoutes(config.RecoConfig{}, "secretKey", r, db, awsSession, events, nil, nil, nil, "foobar", &auth.NOPService{})
 
 	// Create a mock request to the index.
 	req, err := http.NewRequest(http.MethodGet, "/", nil)

--- a/service/batch/batch.go
+++ b/service/batch/batch.go
@@ -1,0 +1,140 @@
+package batch
+
+//go:generate mockgen -source=batch.go -package=batch -destination=batch_mock.go
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/ReconfigureIO/platform/models"
+	"github.com/ReconfigureIO/platform/sugar/noidle"
+)
+
+// Service supplies the ability to run and monitor batch jobs.
+type Service interface {
+	RunBuild(build models.Build, callbackURL, reportsURL string) (string, error)
+	RunGraph(graph models.Graph, callbackURL string) (string, error)
+	RunSimulation(inputArtifactURL, callbackURL, command string) (string, error)
+
+	HaltJob(batchID string) error
+
+	Logs(ctx context.Context, batchJob *models.BatchJob) (io.ReadCloser, error)
+}
+
+// CopyLogs live-streams the logs from batchJob to http.ResponseWriter.
+//
+// Under the hood, it uses pingproto if possible, or otherwise regularly puts
+// nul-bytes on the wire to connection avoid idle timeouts.
+func CopyLogs(
+	ctx context.Context,
+	svc Service,
+	w http.ResponseWriter,
+	r *http.Request,
+	batchJob *models.BatchJob,
+) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // Need this cancel in case closeNotify not supported.
+
+	closeNotify(w, cancel) // Cancel if downstream goes away.
+
+	started, finished := await(ctx, batchJob, func() {
+		// this function needs to update the batch job
+	})
+	<-started
+	go func() {
+		<-finished
+		cancel()
+	}()
+
+	rc, err := svc.Logs(ctx, batchJob)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err2 := rc.Close()
+		if err == nil {
+			err = err2
+		}
+	}()
+
+	// noidle also causes every write to flush, negating the effects of
+	// buffering.
+	appW := noidle.Upgrade(w, r)
+	defer func() {
+		err2 := appW.Close()
+		if err2 != nil {
+			log.WithError(err2).Warnln("CopyLogs: appW.Close")
+		}
+	}()
+
+	_, err = io.Copy(appW, rc)
+	return err
+}
+
+func closeNotify(w http.ResponseWriter, cancel func()) {
+	closeNotifier, ok := w.(http.CloseNotifier)
+	if !ok {
+		return
+	}
+	go func() {
+		<-closeNotifier.CloseNotify()
+		cancel()
+	}()
+}
+
+func await(
+	ctx context.Context,
+	hasStartFinisher interface {
+		HasStarted() bool
+		HasFinished() bool
+	},
+	update func(),
+) (
+	started, finished chan struct{},
+) {
+	started = make(chan struct{})
+	finished = make(chan struct{})
+
+	const pollPeriod = 10 * time.Second
+
+	go func(started, finished chan<- struct{}) {
+		ticker := time.NewTicker(pollPeriod)
+		defer ticker.Stop()
+		tick := ticker.C
+
+		for {
+			select {
+			case <-ctx.Done():
+				if started != nil {
+					close(started)
+				}
+				if finished != nil {
+					close(finished)
+				}
+				return
+			case <-tick:
+			}
+
+			update()
+
+			if started != nil && hasStartFinisher.HasStarted() {
+				close(started)
+				started = nil
+			}
+			if finished != nil && hasStartFinisher.HasFinished() {
+				close(finished)
+				finished = nil
+			}
+
+			if started == nil && finished == nil {
+				return
+			}
+		}
+	}(started, finished)
+
+	return started, finished
+}


### PR DESCRIPTION
Type of change
==============

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

Description
===========
This PR depends on pingproto being vendored, that's covered by this PR: https://github.com/ReconfigureIO/platform/pull/265

The implementations involved depend on no_idle, https://github.com/ReconfigureIO/platform/pull/272

### TODO
 - [x] Add locks to fake-batch logs so deletion and streaming from docker cannot happen at the same time
 - [x] Check container has started before streaming logs

Previously we had the AWS interface under service/aws. It was quite big, it covered all of our interactions with AWS and used one implementation with one client for all of this. Now that we're gearing up for on-prem there's a need to have different aspects of that interface handled by different clients, for instance storage goes to minio while batch jobs go to fake-batch.

This PR aims to break up the AWS interface into Batch, Storage and LogStreaming. This should increase flexibility. It also aims to have implementations for these new interfaces so nothing breaks during the transition. Most of the Batch implementation is the same as it was, likewise the Storage, LogStreaming for AWS has been improved and LogStreaming for fake-batch has been created. 

`cw_id_watcher` has been moved since it was the sole user of a function that added complexity to the AWS interface and didn't fit in the new order. That function got moved up to the cron worker level.

<!--- What does this code solve? How does it solve it? -->

Review Checklist
================

<!--- Don't edit this, the reviewer will. Make sure you follow it though -->

Goals
-----

- [ ] Does it solve the problem?

- [ ] Is it the simplest implementation of that solution?
    Does it yak shave? Does it introduce new dependencies that aren't necessary?

- [ ] Does it decrease modularity?
    Does the user of a module need to import another module to use this one?
    If we want to delete these changes, how easy is that?

- [ ] Does it clarify our domain?
    What things does it refine? What things get added? How does this pave the way for new things?
    Are things named in such a way that a domain expert can find them?

- [ ] Does it introduce non-domain concepts?
    What does the user of this need to learn outside of our domain in order to use this?

Testing
-------

- [ ] Do we integration test changes to external services?

- [ ] Do we unit test code we can change?
