### PR TITLE
Allow machines to pull artifacts from on-prem platform

### DIFF
--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -329,7 +329,6 @@ func (b Build) DownloadArtifact(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	fmt.Println("I got this far boss")
 
 	if build.Status() != "COMPLETED" {
 		sugar.ErrResponse(c, 400, fmt.Sprintf("Build is '%s', not COMPLETED", build.Status()))

--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -329,6 +329,7 @@ func (b Build) DownloadArtifact(c *gin.Context) {
 	if err != nil {
 		return
 	}
+	fmt.Println("I got this far boss")
 
 	if build.Status() != "COMPLETED" {
 		sugar.ErrResponse(c, 400, fmt.Sprintf("Build is '%s', not COMPLETED", build.Status()))
@@ -356,6 +357,5 @@ func (b Build) DownloadArtifact(c *gin.Context) {
 		return
 	}
 
-	c.Header("Content-Encoding", "gzip")
 	c.Data(200, "application/zip", buf.Bytes())
 }

--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -339,6 +339,7 @@ func (b Build) canDownloadArtifact(c *gin.Context, build models.Build) bool {
 func (b Build) DownloadArtifact(c *gin.Context) {
 	build, err := b.unauthOne(c)
 	if err != nil {
+		c.AbortWithError(404, err)
 		return
 	}
 

--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -240,7 +240,10 @@ func (b Build) Logs(c *gin.Context) {
 
 }
 
-func (b Build) canPostEvent(c *gin.Context, build models.Build) bool {
+// authCheck returns true if the API request is coming from the human creator
+// of the object or an automated system with a token that allows it to access
+// the build.
+func (b Build) authCheck(c *gin.Context, build models.Build) bool {
 	user, loggedIn := middleware.CheckUser(c)
 	if loggedIn && build.Project.UserID == user.ID {
 		return true
@@ -259,7 +262,7 @@ func (b Build) CreateEvent(c *gin.Context) {
 		return
 	}
 
-	if !b.canPostEvent(c, build) {
+	if !b.authCheck(c, build) {
 		c.AbortWithStatus(403)
 		return
 	}
@@ -325,8 +328,13 @@ func (b Build) CreateReport(c *gin.Context) {
 }
 
 func (b Build) DownloadArtifact(c *gin.Context) {
-	build, err := b.ByID(c)
+	build, err := b.unauthOne(c)
 	if err != nil {
+		return
+	}
+
+	if !b.authCheck(c, build) {
+		c.AbortWithStatus(403)
 		return
 	}
 

--- a/handlers/api/build_test.go
+++ b/handlers/api/build_test.go
@@ -108,7 +108,6 @@ func TestDownloadArtifact(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		fmt.Println("I made the objects in the DB boss")
 
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -130,8 +129,6 @@ func TestDownloadArtifact(t *testing.T) {
 		}
 		storageService.EXPECT().Download("builds/"+builds[0].ID+"/artifacts.zip").Return(ioutil.NopCloser(bytes.NewReader([]byte("foo"))), nil)
 
-		fmt.Println("I got right up to just before we make the call boss")
 		apiBuild.DownloadArtifact(context)
-
 	})
 }

--- a/handlers/api/build_test.go
+++ b/handlers/api/build_test.go
@@ -3,10 +3,18 @@
 package api
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
 	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/jinzhu/gorm"
 
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/jinzhu/gorm"
+	"github.com/ReconfigureIO/platform/service/storage"
 )
 
 func TestGetPublicBuilds(t *testing.T) {
@@ -44,5 +52,86 @@ func TestGetPublicBuilds(t *testing.T) {
 		if pBuilds[0].ID != builds[0].ID {
 			t.Fatalf("Expected build ID %s, found %s", builds[0].ID, pBuilds[0].ID)
 		}
+	})
+}
+
+func TestDownloadArtifact(t *testing.T) {
+	models.RunTransaction(func(db *gorm.DB) {
+		DB(db)
+		now := time.Now()
+		// create a build in the DB
+		builds := []models.Build{
+			{
+				ID: "foobar",
+				Project: models.Project{
+					User: models.User{
+						ID: "user1",
+					},
+				},
+				BatchJob: models.BatchJob{
+					ID:      1,
+					BatchID: "foobar",
+					Events: []models.BatchJobEvent{
+						models.BatchJobEvent{
+							ID:         "1",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-5 * time.Minute),
+							Status:     "QUEUED",
+						},
+						models.BatchJobEvent{
+							ID:         "2",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-4 * time.Minute),
+							Status:     "STARTED",
+						},
+						models.BatchJobEvent{
+							ID:         "3",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-3 * time.Minute),
+							Status:     "COMPLETED",
+						},
+					},
+				},
+			},
+		}
+
+		user := models.User{
+			ID:       "user1",
+			GithubID: 1,
+			Email:    "foo@bar.com",
+		}
+		db.Create(&user)
+
+		for i := range builds {
+			err := db.Create(&(builds[i])).Error
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		fmt.Println("I made the objects in the DB boss")
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		storageService := storage.NewMockService(mockCtrl)
+
+		context := &gin.Context{
+			Params: []gin.Param{
+				gin.Param{
+					Key:   "id",
+					Value: builds[0].ID,
+				},
+			},
+			Keys: make(map[string]interface{})
+		}
+
+		apiBuild := Build{
+			Storage: storageService,
+		}
+		storageService.EXPECT().Download("builds/"+builds[0].ID+"/artifacts.zip").Return(ioutil.NopCloser(bytes.NewReader([]byte("foo"))), nil)
+
+		fmt.Println("I got right up to just before we make the call boss")
+		apiBuild.DownloadArtifact(context)
+
 	})
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -90,6 +90,9 @@ func SetupRoutes(
 		buildRoute.PUT("/:id/input", build.Input)
 		buildRoute.GET("/:id/logs", build.Logs)
 		buildRoute.GET("/:id/reports", build.Report)
+		if config.Env == "development-on-prem" {
+			buildRoute.GET("/:id/artifacts", build.DownloadArtifact)
+		}
 	}
 
 	project := api.Project{

--- a/service/storage/storage.go
+++ b/service/storage/storage.go
@@ -1,5 +1,7 @@
 package storage
 
+//go:generate mockgen -source=storage.go -package=storage -destination=storage_mock.go
+
 import "io"
 
 // A Service provides a content store.


### PR DESCRIPTION
The idea here is that we currently have AWS EC2 create an F1 instance and a separate EC2 API call loads that F1 instance with the AFI/bitstream generated by a build. On-prem we don't have that functionality so we need to replicate it somehow. 

The two key components are downloading the AFI/bitstream, and loading this bitstream into the FPGA. This PR is the first version of the downloading bitstream functionality. I envision there will be some daemon running on servers with attached FPGAs to act as a client when downloading a bitstream and they will also program the FPGA.

The added API feature is that a HTTP GET to <api>/builds/<build-id>/artifacts returns the artifacts.zip file generated by the build. Since a user with access to this zip could theoretically spawn their own F1 instance and load its contents to their own FPGA, bypassing our chargeable deployments, this endpoint should not be exposed to users. At the moment use of this endpoint requires authentication using the token attached to a Build which is only handed out to workers for things like event posting.

### What is blocking this PR?
We'll need some functionality like this eventually for on-prem but it's not currently needed for our Cloud offering.