### PR TITLE
Remove unused aws.Service in cron, breaking dependency on service/aws

### DIFF
--- a/cmd/cron/main.go
+++ b/cmd/cron/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ReconfigureIO/platform/config"
 	"github.com/ReconfigureIO/platform/handlers/api"
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/ReconfigureIO/platform/service/aws"
 	"github.com/ReconfigureIO/platform/service/billing_hours"
 	"github.com/ReconfigureIO/platform/service/cw_id_watcher"
 	"github.com/ReconfigureIO/platform/service/deployment"
@@ -28,7 +27,6 @@ import (
 
 var (
 	deploy          deployment.Service
-	awsService      aws.Service
 	awsBatchService batchiface.BatchAPI
 
 	db *gorm.DB
@@ -55,7 +53,6 @@ func setup(*cobra.Command, []string) {
 	}
 
 	deploy = deployment.New(conf.Reco.Deploy)
-	awsService = aws.New(conf.Reco.AWS)
 
 	sess := session.New()
 	awsBatchService = batch.New(sess)


### PR DESCRIPTION
<!-- First time? Take a look at: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/ -->
This PR removes an unused variable in cron/main.go and in doing so removes the need for cron/main.go to import our service/aws. Elsewhere (PR tbc) I'm moving the aws.Service interface into batch.Service which service/aws implements so everything that imports service/aws needs updating, in doing so I spotted this opportunity to remove a dependency.

It's a good thing too as cron/main.go already imports a module called batch from the AWS Go SDK so there would have been a naming conflict to resolve.

As for why aws.Service's interface is being moved, I'm trying to break down the large fake-batch-fixes PR into sensible chunks, one such chunk would be the change from a large aws.Service interface into a much smaller batch.Service interface.
<!-- PR Body. Describe the purpose of the change here. -->

<!-- What feedback do you want from the review? -->
In terms of feedback I'd like a double-check that this variable isn't used. Cron builds without it, a ctrl+f doesn't find any other mentions in related files so I'm fairly sure it's safe.

Checklist
=========

- [x] Thought about testing?
- [x] Is the intent of the code clear? (use comments judiciously!)
- [x] Added to RELEASE.md?

<!--

    Have you told everyone that needs to know about this PR?

    Do you need to update global docs?
        https://github.com/ReconfigureIO/internal-docs/wiki/Engineering-Function

    You *are* allowed to delete the contents of this template.
    Please strive to make the intent of your change clear in the PR.

-->
