### PR TITLE
Move AWS interface to Batch interface and start using it

### DIFF
--- a/handlers/api/batch.go
+++ b/handlers/api/batch.go
@@ -4,12 +4,12 @@ import (
 	"time"
 
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 )
 
 // BatchService is aws batch job service.
 type BatchService struct {
-	AWS aws.Service
+	AWS batch.Service
 }
 
 // New creates a new batch job with its queued event.

--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/storage"
 
 	"github.com/ReconfigureIO/platform/middleware"
@@ -20,7 +20,7 @@ import (
 type Build struct {
 	Events          events.EventService
 	Storage         storage.Service
-	AWS             aws.Service
+	AWS             batch.Service
 	PublicProjectID string
 }
 

--- a/handlers/api/deployment.go
+++ b/handlers/api/deployment.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/deployment"
 	"github.com/ReconfigureIO/platform/service/storage"
 
@@ -30,7 +30,7 @@ type Deployment struct {
 	UseSpotInstances bool
 	Storage          storage.Service
 	DeployService    deployment.Service
-	AWS              aws.Service
+	AWS              batch.Service
 	PublicProjectID  string
 }
 

--- a/handlers/api/graph.go
+++ b/handlers/api/graph.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ReconfigureIO/platform/middleware"
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/events"
 	"github.com/ReconfigureIO/platform/service/storage"
 	"github.com/ReconfigureIO/platform/sugar"
@@ -20,7 +20,7 @@ import (
 type Graph struct {
 	Events  events.EventService
 	Storage storage.Service
-	AWS     aws.Service
+	AWS     batch.Service
 }
 
 // Common preload functionality.

--- a/handlers/api/logStream.go
+++ b/handlers/api/logStream.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ReconfigureIO/platform/models"
 	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/deployment"
 	"github.com/ReconfigureIO/platform/service/stream"
 	"github.com/ReconfigureIO/platform/sugar"
@@ -18,7 +19,7 @@ import (
 )
 
 // StreamBatchLogs streams batch logs from AWS.
-func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob) {
+func StreamBatchLogs(awsSession batch.Service, c *gin.Context, b *models.BatchJob) {
 	ctx, cancel := WithClose(c)
 	defer cancel()
 
@@ -91,7 +92,7 @@ func StreamBatchLogs(awsSession aws.Service, c *gin.Context, b *models.BatchJob)
 	stream.Start(ctx, lstream, c, awsSession.Conf().LogGroup)
 }
 
-func streamDeploymentLogs(service deployment.Service, awsSession aws.Service, c *gin.Context, deployment *models.Deployment) {
+func streamDeploymentLogs(service deployment.Service, awsSession batch.Service, c *gin.Context, deployment *models.Deployment) {
 	ctx, cancel := WithClose(c)
 	defer cancel()
 

--- a/handlers/api/simulation.go
+++ b/handlers/api/simulation.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ReconfigureIO/platform/middleware"
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/events"
 	"github.com/ReconfigureIO/platform/service/storage"
 	"github.com/ReconfigureIO/platform/sugar"
@@ -16,13 +16,13 @@ import (
 
 // Simulation handles simulation requests.
 type Simulation struct {
-	AWS     aws.Service
+	AWS     batch.Service
 	Events  events.EventService
 	Storage storage.Service
 }
 
 // NewSimulation creates a new Simulation.
-func NewSimulation(events events.EventService, storageService storage.Service, awsSession aws.Service) Simulation {
+func NewSimulation(events events.EventService, storageService storage.Service, awsSession batch.Service) Simulation {
 	return Simulation{
 		AWS:     awsSession,
 		Events:  events,

--- a/handlers/api/simulation_test.go
+++ b/handlers/api/simulation_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/golang/mock/gomock"
 )
 
@@ -11,7 +11,7 @@ func Test_ServiceInterface(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	s := aws.NewMockService(mockCtrl)
+	s := batch.NewMockService(mockCtrl)
 	s.EXPECT().RunSimulation("foo", "bar", "test").Return("foobar", nil)
 	ss, err := s.RunSimulation("foo", "bar", "test")
 	if err != nil || ss != "foobar" {

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ReconfigureIO/platform/handlers/profile"
 	"github.com/ReconfigureIO/platform/middleware"
 	"github.com/ReconfigureIO/platform/service/auth"
-	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/deployment"
 	"github.com/ReconfigureIO/platform/service/events"
 	"github.com/ReconfigureIO/platform/service/leads"
@@ -23,7 +23,7 @@ func SetupRoutes(
 	secretKey string,
 	r *gin.Engine,
 	db *gorm.DB,
-	awsService aws.Service,
+	awsService batch.Service,
 	events events.EventService,
 	leads leads.Leads,
 	storage storage.Service,

--- a/service/batch/batch.go
+++ b/service/batch/batch.go
@@ -1,0 +1,26 @@
+package batch
+
+//go:generate mockgen -source=batch.go -package=batch -destination=batch_mock.go
+
+import (
+	"github.com/ReconfigureIO/platform/models"
+	"github.com/ReconfigureIO/platform/service/aws"
+	"github.com/aws/aws-sdk-go/service/batch"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+)
+
+// Service is a Batch service.
+type Service interface {
+	RunBuild(build models.Build, callbackURL string, reportsURL string) (string, error)
+	RunGraph(graph models.Graph, callbackURL string) (string, error)
+	RunSimulation(inputArtifactURL string, callbackURL string, command string) (string, error)
+	RunDeployment(command string) (string, error)
+
+	HaltJob(batchID string) error
+	GetJobDetail(id string) (*batch.JobDetail, error)
+
+	NewStream(stream cloudwatchlogs.LogStream) *aws.Stream
+	GetJobStream(string) (*cloudwatchlogs.LogStream, error)
+
+	Conf() *aws.ServiceConfig
+}


### PR DESCRIPTION
<!-- First time? Take a look at: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/ -->
This PR is part of the work to reduce the large fake-batch-fixes branch down to a manageable size. This PR creates the batch.Service interface which is a copy of the one that used to be in aws.Service. This PR also updates all the files that used aws.Service to use batch.Service.

<!-- PR Body. Describe the purpose of the change here. -->

<!-- What feedback do you want from the review? -->

Checklist
=========

- [x] Thought about testing?
- [x] Is the intent of the code clear? (use comments judiciously!)
- [x] Added to RELEASE.md?

<!--

    Have you told everyone that needs to know about this PR?

    Do you need to update global docs?
        https://github.com/ReconfigureIO/internal-docs/wiki/Engineering-Function

    You *are* allowed to delete the contents of this template.
    Please strive to make the intent of your change clear in the PR.

-->
