### PR TITLE
Allow machines to pull artifacts from on-prem platform

### DIFF
--- a/handlers/api/build.go
+++ b/handlers/api/build.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
 	"github.com/ReconfigureIO/platform/service/batch"
 	"github.com/ReconfigureIO/platform/service/storage"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ReconfigureIO/platform/middleware"
 	"github.com/ReconfigureIO/platform/models"
@@ -307,4 +309,57 @@ func (b Build) CreateReport(c *gin.Context) {
 	}
 
 	sugar.SuccessResponse(c, 200, nil)
+}
+
+func (b Build) canDownloadArtifact(c *gin.Context, build models.Build) bool {
+	user, loggedIn := middleware.CheckUser(c)
+	if loggedIn && build.Project.UserID == user.ID {
+		return true
+	}
+	token, exists := c.GetQuery("token")
+	if exists && build.Token == token {
+		return true
+	}
+	return false
+}
+
+func (b Build) DownloadArtifact(c *gin.Context) {
+	build, err := b.unauthOne(c)
+	if err != nil {
+		c.AbortWithError(404, err)
+		return
+	}
+
+	if !b.canDownloadArtifact(c, build) {
+		c.AbortWithStatus(403)
+		return
+	}
+
+	if build.Status() != "COMPLETED" {
+		sugar.ErrResponse(c, 400, fmt.Sprintf("Build is '%s', not COMPLETED", build.Status()))
+		return
+	}
+
+	object, err := b.Storage.Download(build.ArtifactUrl())
+	if object != nil {
+		defer func() {
+			err := object.Close()
+			if err != nil {
+				log.WithError(err).Error("Failed to close b.Storage.Download")
+			}
+		}()
+	}
+	if err != nil {
+		sugar.InternalError(c, err)
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(object)
+	if err != nil {
+		sugar.InternalError(c, err)
+		return
+	}
+
+	c.Data(200, "application/zip", buf.Bytes())
 }

--- a/handlers/api/build_test.go
+++ b/handlers/api/build_test.go
@@ -3,10 +3,20 @@
 package api
 
 import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/jinzhu/gorm"
 
 	"github.com/ReconfigureIO/platform/models"
-	"github.com/jinzhu/gorm"
+	"github.com/ReconfigureIO/platform/service/storage"
 )
 
 func TestGetPublicBuilds(t *testing.T) {
@@ -44,5 +54,95 @@ func TestGetPublicBuilds(t *testing.T) {
 		if pBuilds[0].ID != builds[0].ID {
 			t.Fatalf("Expected build ID %s, found %s", builds[0].ID, pBuilds[0].ID)
 		}
+	})
+}
+
+func TestDownloadArtifact(t *testing.T) {
+	models.RunTransaction(func(db *gorm.DB) {
+		DB(db)
+		now := time.Now()
+
+		user := models.User{
+			GithubID: 1,
+			Email:    "foo@bar.com",
+		}
+		db.Create(&user)
+
+		builds := []models.Build{
+			{
+				Token: "foobar",
+				Project: models.Project{
+					User: models.User{
+						ID: user.ID,
+					},
+				},
+				BatchJob: models.BatchJob{
+					ID:      1,
+					BatchID: "foobar",
+					Events: []models.BatchJobEvent{
+						models.BatchJobEvent{
+							ID:         "1",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-5 * time.Minute),
+							Status:     "QUEUED",
+						},
+						models.BatchJobEvent{
+							ID:         "2",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-4 * time.Minute),
+							Status:     "STARTED",
+						},
+						models.BatchJobEvent{
+							ID:         "3",
+							BatchJobID: 1,
+							Timestamp:  now.Add(-3 * time.Minute),
+							Status:     "COMPLETED",
+						},
+					},
+				},
+			},
+		}
+
+		for i := range builds {
+			err := db.Create(&(builds[i])).Error
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		storageService := storage.NewMockService(mockCtrl)
+		storageService.EXPECT().Download("builds/"+builds[0].ID+"/artifacts.zip").Return(ioutil.NopCloser(bytes.NewReader([]byte("foo"))), nil)
+
+		build := Build{
+			Storage: storageService,
+		}
+		r := gin.Default()
+		r.GET("builds/:id/artifacts", build.DownloadArtifact)
+
+		// Test if human user auth lets you download artifacts
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/builds/"+builds[0].ID+"/artifacts", nil)
+		req.SetBasicAuth(strconv.Itoa(user.GithubID), user.Token)
+		r.ServeHTTP(w, req)
+
+		if w.Code == 200 {
+			t.Error("Human user was allowed to download artifacts")
+		}
+
+		// Test if machine token auth lets you download artifacts
+		w = httptest.NewRecorder()
+		req, _ = http.NewRequest("GET", "/builds/"+builds[0].ID+"/artifacts?token="+builds[0].Token, nil)
+		r.ServeHTTP(w, req)
+
+		if w.Code != 200 {
+			t.Fatalf("Machine could not download artifact, response code: %v", w.Code)
+		}
+
+		if w.Body.String() != "foo" {
+			t.Fatalf("Expected artifact contents to be foo, got %v \n", w.Body.String())
+		}
+
 	})
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -85,6 +85,9 @@ func SetupRoutes(
 		buildRoute.PUT("/:id/input", build.Input)
 		buildRoute.GET("/:id/logs", build.Logs)
 		buildRoute.GET("/:id/reports", build.Report)
+		if config.Env == "development-on-prem" {
+			buildRoute.GET("/:id/artifacts", build.DownloadArtifact)
+		}
 	}
 
 	project := api.Project{

--- a/service/storage/storage.go
+++ b/service/storage/storage.go
@@ -1,5 +1,7 @@
 package storage
 
+//go:generate mockgen -source=storage.go -package=storage -destination=storage_mock.go
+
 import "io"
 
 // A Service provides a content store.


### PR DESCRIPTION
<!-- First time? Take a look at: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/ -->
# This is a re-do of PR #274 
<!-- PR Body. Describe the purpose of the change here. -->

The idea here is that we currently have AWS EC2 create an F1 instance and a separate EC2 API call loads that F1 instance with the AFI/bitstream generated by a build. On-prem we don't have that functionality so we need to replicate it somehow. 

The two key components are downloading the AFI/bitstream, and loading this bitstream into the FPGA. This PR is the first version of the downloading bitstream functionality. I envision there will be some daemon running on servers with attached FPGAs to act as a client when downloading a bitstream and they will also program the FPGA.

The added API feature is that a HTTP GET to <api>/builds/<build-id>/artifacts returns the artifacts.zip file generated by the build. Since a user with access to this zip could theoretically spawn their own F1 instance and load its contents to their own FPGA, bypassing our chargeable deployments, this endpoint should not be exposed to users. At the moment use of this endpoint requires authentication using the token attached to a Build which is only handed out to workers for things like event posting.

### What is blocking this PR?
We'll need some functionality like this eventually for on-prem but it's not currently needed for our Cloud offering.

<!-- What feedback do you want from the review? -->

Checklist
=========

- [x] Thought about testing?
- [x] Is the intent of the code clear? (use comments judiciously!)
- [x] Added to RELEASE.md?

<!--

    Have you told everyone that needs to know about this PR?

    Do you need to update global docs?
        https://github.com/ReconfigureIO/internal-docs/wiki/Engineering-Function

    You *are* allowed to delete the contents of this template.
    Please strive to make the intent of your change clear in the PR.

-->
