### PR TITLE
Make fake-batch use fake-reco-sdaccel for testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,16 @@ pipeline {
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
-        PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${PATH}"
+        PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
+
+        
+
+    stages {
+        stage('Test') {
+            steps {
+                echo "PATH : ${env.PATH}"
+                echo "PATHX: ${env.PATHX}"
+                sh "printenv | grep PATH"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))
@@ -23,6 +32,14 @@ pipeline {
         stage("notify") {
             steps {
                 slackSend (color: '#FFFF00', message: "STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+            }
+        }
+
+        stage('test env vars') {
+            steps {
+                echo "PATH : ${env.PATH}"
+                echo "PATHX: ${env.PATHX}"
+                sh "printenv | grep PATH"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
-        PATH = "${env.GOPATH}/bin:/usr/lib/go-1.10/bin:${PATH}"
+        env.PATH = "${env.GOPATH}/bin:/usr/lib/go-1.10/bin:${PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,7 @@ pipeline {
 
         stage('host-only tests') {
             steps {
+                dir ("{env.GOPATH}/bin") {}
                 sh 'curl https://glide.sh/get | sh'
                 sh 'make dependencies'
                 sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,13 @@ pipeline {
             }
         }
 
+        stage('host-only tests') {
+            steps {
+                sh 'make dependencies'
+                sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'
+            }
+        }
+
         stage('clean') {
             steps {
                 sh 'docker-compose run --rm web-base make clean'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,9 +54,8 @@ pipeline {
 
         stage('host-only tests') {
             steps {
-                dir ("{env.GOPATH}/bin") {
-                    sh 'curl https://glide.sh/get | sh'
-                }
+                sh 'mkdir ./go/bin -p'
+                sh 'curl https://glide.sh/get | sh'
                 sh 'make dependencies'
                 sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
         PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
-        PATHX = "foobar"
+        PATHX = "${env.WORKSPACE}:${env.PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,15 +6,6 @@ pipeline {
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
         PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
-
-        
-
-    stages {
-        stage('Test') {
-            steps {
-                echo "PATH : ${env.PATH}"
-                echo "PATHX: ${env.PATHX}"
-                sh "printenv | grep PATH"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
-        env.PATH = "${env.GOPATH}/bin:/usr/lib/go-1.10/bin:${PATH}"
+        PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,7 @@ pipeline {
         stage('host-only tests') {
             steps {
                 sh 'mkdir ./go/bin -p'
+                sh 'mkdir ./go/src -p'
                 sh 'curl https://glide.sh/get | sh'
                 sh 'make dependencies'
                 sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
-        PATH = "${env.GOPATH}/bin:${PATH}"
+        PATH = "${env.GOPATH}/bin:/usr/lib/go-1.10/bin:${PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
         PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
-        PATHX = "${env.WORKSPACE}:${env.PATH}"
+        PATHX = "${env.WORKSPACE}" + ":" + "${env.PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
         PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
+        PATHX = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
         GOPATH = "${env.WORKSPACE}/go"
         PATH = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
-        PATHX = "${env.WORKSPACE}/go/bin:/usr/lib/go-1.10/bin:${env.PATH}"
+        PATHX = "foobar"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,8 +54,9 @@ pipeline {
 
         stage('host-only tests') {
             steps {
-                dir ("{env.GOPATH}/bin") {}
-                sh 'curl https://glide.sh/get | sh'
+                dir ("{env.GOPATH}/bin") {
+                    sh 'curl https://glide.sh/get | sh'
+                }
                 sh 'make dependencies'
                 sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
         AWS_REGION = "us-east-1"
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
-        GOPATH= "${env.WORKSPACE}/go"
-        PATH="${env.GOPATH}/bin:${env.PATH}"
+        GOPATH = "${env.WORKSPACE}/go"
+        PATH = "${env.GOPATH}/bin:${PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,8 @@ pipeline {
         AWS_REGION = "us-east-1"
         KOPS_STATE_STORE = "S3://k8s-reconfigure-infra"
         RECO_INTERCOM_ACCESS_TOKEN = credentials('intercom_token')
+        GOPATH= "${env.WORKSPACE}/go"
+        PATH="${env.GOPATH}/bin:${env.PATH}"
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: '', numToKeepStr: '20'))
@@ -52,6 +54,7 @@ pipeline {
 
         stage('host-only tests') {
             steps {
+                sh 'curl https://glide.sh/get | sh'
                 sh 'make dependencies'
                 sh 'go test -tags=host_only -v $(go list ./... | grep -v /vendor/ | grep -v /cmd/)'
             }

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,4 @@
 FROM golang:1.9.1
 RUN apt-get update && apt-get install -y
-RUN apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    software-properties-common
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   $(lsb_release -cs) \
-   stable"
-RUN apt-get update && apt-get install -y docker-ce
 RUN curl https://glide.sh/get | sh
 RUN go get -v github.com/pilu/fresh

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,15 @@
 FROM golang:1.9.1
 RUN apt-get update && apt-get install -y
+RUN apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update && apt-get install -y docker-ce
 RUN curl https://glide.sh/get | sh
 RUN go get -v github.com/pilu/fresh

--- a/cmd/fake-batch/main.go
+++ b/cmd/fake-batch/main.go
@@ -18,17 +18,26 @@ func main() {
 		log.Fatalf("Unable to configure docker client: %v", err)
 	}
 
-	// Make a map of JobDefinitions to pass to handler
 	jobDefinitions := map[string]JobDefinition{
-		"fake-batch-job-definition": JobDefinition{
-			Image: "ubuntu:latest",
-		},
 		"sdaccel-builder-build": JobDefinition{
 			Image: "398048034572.dkr.ecr.us-east-1.amazonaws.com/reconfigureio/build-framework/sdaccel-builder:v0.17.5",
 			MountPoints: []string{
 				"/opt/Xilinx:/opt/Xilinx",
 			},
 		},
+	}
+	if os.Getenv("RECO_ENV") == "development" {
+		jobDefinitions = map[string]JobDefinition{
+			"ubuntu": JobDefinition{
+				Image: "ubuntu:latest",
+			},
+			"sdaccel-builder-build": JobDefinition{
+				Image: "fake-sdaccel-builder:latest",
+				MountPoints: []string{
+					"/opt/Xilinx:/opt/Xilinx",
+				},
+			},
+		}
 	}
 
 	handler := &handler{

--- a/cmd/fake-batch/main.go
+++ b/cmd/fake-batch/main.go
@@ -20,24 +20,11 @@ func main() {
 
 	jobDefinitions := map[string]JobDefinition{
 		"sdaccel-builder-build": JobDefinition{
-			Image: "398048034572.dkr.ecr.us-east-1.amazonaws.com/reconfigureio/build-framework/sdaccel-builder:v0.17.5",
+			Image: os.Getenv("RECO_COMPILER_IMAGE"),
 			MountPoints: []string{
 				"/opt/Xilinx:/opt/Xilinx",
 			},
 		},
-	}
-	if os.Getenv("RECO_ENV") == "development" {
-		jobDefinitions = map[string]JobDefinition{
-			"ubuntu": JobDefinition{
-				Image: "ubuntu:latest",
-			},
-			"sdaccel-builder-build": JobDefinition{
-				Image: "fake-sdaccel-builder:latest",
-				MountPoints: []string{
-					"/opt/Xilinx:/opt/Xilinx",
-				},
-			},
-		}
 	}
 
 	handler := &handler{

--- a/docker-compose.on-prem.yml
+++ b/docker-compose.on-prem.yml
@@ -101,6 +101,10 @@ services:
       - RECO_FEATURE_DEP_QUEUE=1
       - RECO_PUBLIC_PROJECT_ID=a95550bf-bffa-42df-b100-872501940c5c
 
+  fake-sdaccel-builder:
+    build: ./fake-sdaccel-builder
+    image: fake-sdaccel-builder:latest
+
 networks:
   platform:
     driver: bridge

--- a/docker-compose.on-prem.yml
+++ b/docker-compose.on-prem.yml
@@ -70,6 +70,7 @@ services:
       - AWS_ACCESS_KEY_ID=foo
       - AWS_SECRET_ACCESS_KEY=foobarbaz
       - S3_ENDPOINT=http://minio.test:9000/
+      - RECO_COMPILER_IMAGE=fake-sdaccel-builder:latest
     command: bash -c "make clean dist-image/dist/fake-batch && ./dist-image/dist/fake-batch"
 
   web:
@@ -101,6 +102,11 @@ services:
       - RECO_FEATURE_DEP_QUEUE=1
       - RECO_PUBLIC_PROJECT_ID=a95550bf-bffa-42df-b100-872501940c5c
 
+# fake-sdaccel-builder is a fake version of our production compiler container
+# image, sdaccel-builder. It sends events and generates logs but doesn't
+# interact with Vivado. We've added it here so that its build is triggered
+# during a 'docker-compose up', after that it can be used by fake-batch during
+# development
   fake-sdaccel-builder:
     build: ./fake-sdaccel-builder
     image: fake-sdaccel-builder:latest

--- a/docker-compose.on-prem.yml
+++ b/docker-compose.on-prem.yml
@@ -44,6 +44,8 @@ services:
 
   test:
     extends: web-base
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - db
       - web-base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
 
   test:
     extends: web-base
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - db
       - web-base

--- a/fake-sdaccel-builder/Dockerfile
+++ b/fake-sdaccel-builder/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.8
+
+RUN apk add bash curl
+
+COPY aws/*.sh /opt/
+WORKDIR /mnt

--- a/fake-sdaccel-builder/aws/build.sh
+++ b/fake-sdaccel-builder/aws/build.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/bin/bash 
+# This script mimics the equivalent script (reco-sdaccel/aws/build.sh)
+# which is used in our production compiler. It produces some basic logs and
+# posts events to platform's events API but it has fewer system requirements
+# than the production script making it easier to test against during end to end
+# testing, for instance it does not require Vivado or run for 4+ hours. 
 set -e
 
 function post_event {

--- a/fake-sdaccel-builder/aws/build.sh
+++ b/fake-sdaccel-builder/aws/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+function post_event {
+    curl -XPOST -H "Content-Type: application/json"  -d '{"status": "'"$1"'", "message": "'"$2"'", "code": '${3-0}'}' "$CALLBACK_URL" &> /dev/null
+}
+
+post_event STARTED
+
+echo "downloading source code... done"
+
+echo "compiling host cmds... done"
+
+echo "compiling fpga kernel..."
+
+for i in $(seq 1 100)
+    do echo $i%
+    sleep 1
+done
+
+echo "uploading artifacts... done"
+
+post_event COMPLETED

--- a/fake-sdaccel-builder/aws/build.sh
+++ b/fake-sdaccel-builder/aws/build.sh
@@ -20,7 +20,7 @@ echo "compiling fpga kernel..."
 
 for i in $(seq 1 100)
     do echo $i%
-    sleep 1
+    sleep $SLEEP_PERIOD
 done
 
 echo "uploading artifacts... done"

--- a/fake-sdaccel-builder/aws/graph.sh
+++ b/fake-sdaccel-builder/aws/graph.sh
@@ -1,4 +1,9 @@
-#!/bin/bash
+#!/bin/bash 
+# This script mimics the equivalent script (reco-sdaccel/aws/graph.sh)
+# which is used in our production compiler. It produces some basic logs and
+# posts events to platform's events API but it has fewer system requirements
+# than the production script making it easier to test against during end to end
+# testing, for instance it does not require Vivado or run for 4+ hours. 
 set -e
 
 function post_event {

--- a/fake-sdaccel-builder/aws/graph.sh
+++ b/fake-sdaccel-builder/aws/graph.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+function post_event {
+    curl -XPOST -H "Content-Type: application/json"  -d '{"status": "'"$1"'", "message": "'"$2"'", "code": '${3-0}'}' "$CALLBACK_URL" &> /dev/null
+}
+
+post_event STARTED
+
+echo "downloading source code... done"
+
+echo "generating graph..."
+
+for i in $(seq 1 100)
+    do echo $i%
+    sleep 1
+done
+
+echo "uploading graph... done"
+
+post_event COMPLETED

--- a/fake-sdaccel-builder/aws/graph.sh
+++ b/fake-sdaccel-builder/aws/graph.sh
@@ -18,7 +18,7 @@ echo "generating graph..."
 
 for i in $(seq 1 100)
     do echo $i%
-    sleep 1
+    sleep $SLEEP_PERIOD
 done
 
 echo "uploading graph... done"

--- a/fake-sdaccel-builder/aws/simulate.sh
+++ b/fake-sdaccel-builder/aws/simulate.sh
@@ -19,7 +19,7 @@ echo "running simulation..."
 
 for i in $(seq 1 100)
     do echo $i%
-    sleep 1
+    sleep $SLEEP_PERIOD
 done
 
 post_event COMPLETED

--- a/fake-sdaccel-builder/aws/simulate.sh
+++ b/fake-sdaccel-builder/aws/simulate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+function post_event {
+    curl -XPOST -H "Content-Type: application/json"  -d '{"status": "'"$1"'", "message": "'"$2"'", "code": '${3-0}'}' "$CALLBACK_URL" &> /dev/null
+}
+
+post_event STARTED
+
+echo "downloading source code... done"
+
+echo "running simulation..."
+
+for i in $(seq 1 100)
+    do echo $i%
+    sleep 1
+done
+
+post_event COMPLETED

--- a/fake-sdaccel-builder/aws/simulate.sh
+++ b/fake-sdaccel-builder/aws/simulate.sh
@@ -1,8 +1,14 @@
-#!/bin/bash
+#!/bin/bash 
+# This script mimics the equivalent script
+# (reco-sdaccel/aws/simulate.sh) which is used in our production compiler. It
+# produces some basic logs and posts events to platform's events API but it has
+# fewer system requirements than the production script making it easier to test
+# against during end to end testing, for instance it does not require Vivado or
+# run for 4+ hours. 
 set -e
 
 function post_event {
-    curl -XPOST -H "Content-Type: application/json"  -d '{"status": "'"$1"'", "message": "'"$2"'", "code": '${3-0}'}' "$CALLBACK_URL" &> /dev/null
+    curl -XPOST -H "Content-Type: application/json"  -d '{"status": "'"$1"'", "message": "'"$2"'", "code": '${3-0}'}' "$CALLBACK_URL" &> /dev/null ; true
 }
 
 post_event STARTED

--- a/fake-sdaccel-builder/main_test.go
+++ b/fake-sdaccel-builder/main_test.go
@@ -52,6 +52,9 @@ func prebuildImage() (string, error) {
 		"docker", "build", "--quiet", "./",
 	)
 	id, err := cmd.CombinedOutput()
+	if len(id) == 0 {
+		panic("No output from docker build")
+	}
 	return string(id[:len(id)-3]), err
 }
 

--- a/fake-sdaccel-builder/main_test.go
+++ b/fake-sdaccel-builder/main_test.go
@@ -1,3 +1,5 @@
+// +build host_only
+
 package main_test
 
 import (
@@ -63,13 +65,14 @@ type context struct {
 }
 
 func TestFakeSdaccelBuilder(t *testing.T) {
-	id, err := prebuildImage()
+	imageid, err := prebuildImage()
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx := context{
-		imageID: id,
+		imageID: imageid,
 	}
+
 	t.Run("shell-scripts", func(t *testing.T) {
 		t.Run("graph.sh", ctx.testGraphDotSh)
 		t.Run("build.sh", ctx.testBuildDotSh)

--- a/fake-sdaccel-builder/main_test.go
+++ b/fake-sdaccel-builder/main_test.go
@@ -1,0 +1,247 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+)
+
+type eventMessage struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+func findIP() net.IP {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if iface.Flags&(net.FlagLoopback) != 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			panic(err)
+		}
+		for _, addr := range addrs {
+			if ip, ok := addr.(*net.IPNet); ok {
+				if theIP := ip.IP.To4(); len(theIP) == net.IPv4len {
+					return theIP
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func prebuildImage() (string, error) {
+	cmd := exec.Command(
+		"docker", "build", "--quiet", "./",
+	)
+	id, err := cmd.CombinedOutput()
+	return string(id[:len(id)-3]), err
+}
+
+type context struct {
+	imageID string
+}
+
+func TestFakeSdaccelBuilder(t *testing.T) {
+	id, err := prebuildImage()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context{
+		imageID: id,
+	}
+	t.Run("shell-scripts", func(t *testing.T) {
+		t.Run("graph.sh", ctx.testGraphDotSh)
+		t.Run("build.sh", ctx.testBuildDotSh)
+		t.Run("simulate.sh", ctx.testSimulateDotSh)
+	})
+}
+
+func (c context) testGraphDotSh(t *testing.T) {
+	t.Parallel()
+	var started bool
+	var completed bool
+	expectedLineCount := 103
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		var event eventMessage
+		err = json.Unmarshal(body, &event)
+		if err != nil {
+			panic(err)
+		}
+		switch event.Status {
+		case "STARTED":
+			started = true
+		case "COMPLETED":
+			completed = true
+		}
+	}))
+
+	ip := findIP()
+	var err error
+	s.Listener, err = net.Listen("tcp4", ip.String()+":0")
+	if err != nil {
+		panic(err)
+	}
+	s.Start()
+	defer s.Close()
+
+	cmd := exec.Command(
+		"docker", "run", "--rm",
+		"--env=CALLBACK_URL="+s.URL+"/events/",
+		"--env=SLEEP_PERIOD=0.001",
+		""+c.imageID,
+		"/opt/graph.sh",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Docker run output: %s \n", string(output[:]))
+		t.Fatal(err)
+	}
+	count := bytes.Count(output, []byte("\n"))
+
+	if !started {
+		t.Error("Did not recieve STARTED event from script\n")
+	}
+	if !completed {
+		t.Error("Did not recieve COMPLETED event from script\n")
+	}
+	if count < expectedLineCount {
+		t.Errorf("Did not recieve expected number of output lines. Expected: %v Recieved: %v\n", expectedLineCount, count)
+	}
+}
+
+func (c context) testBuildDotSh(t *testing.T) {
+	t.Parallel()
+	var started bool
+	var completed bool
+	expectedLineCount := 104
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		var event eventMessage
+		err = json.Unmarshal(body, &event)
+		if err != nil {
+			panic(err)
+		}
+		switch event.Status {
+		case "STARTED":
+			started = true
+		case "COMPLETED":
+			completed = true
+		}
+	}))
+
+	ip := findIP()
+	var err error
+	s.Listener, err = net.Listen("tcp4", ip.String()+":0")
+	if err != nil {
+		panic(err)
+	}
+	s.Start()
+	defer s.Close()
+
+	cmd := exec.Command(
+		"docker", "run", "--rm",
+		"--env=CALLBACK_URL="+s.URL+"/events/",
+		"--env=SLEEP_PERIOD=0.001",
+		""+c.imageID,
+		"/opt/graph.sh",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := bytes.Count(output, []byte("\n"))
+
+	if !started {
+		t.Error("Did not recieve STARTED event from script\n")
+	}
+	if !completed {
+		t.Error("Did not recieve COMPLETED event from script\n")
+	}
+	if count < expectedLineCount {
+		t.Errorf("Did not recieve expected number of output lines. Expected: %v Recieved: %v\n", expectedLineCount, count)
+	}
+}
+
+func (c context) testSimulateDotSh(t *testing.T) {
+	t.Parallel()
+	var started bool
+	var completed bool
+	expectedLineCount := 102
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		var event eventMessage
+		err = json.Unmarshal(body, &event)
+		if err != nil {
+			panic(err)
+		}
+		switch event.Status {
+		case "STARTED":
+			started = true
+		case "COMPLETED":
+			completed = true
+		}
+	}))
+
+	ip := findIP()
+	var err error
+	s.Listener, err = net.Listen("tcp4", ip.String()+":0")
+	if err != nil {
+		panic(err)
+	}
+	s.Start()
+	defer s.Close()
+
+	cmd := exec.Command(
+		"docker", "run", "--rm",
+		"--env=CALLBACK_URL="+s.URL+"/events/",
+		"--env=SLEEP_PERIOD=0.001",
+		""+c.imageID,
+		"/opt/graph.sh",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := bytes.Count(output, []byte("\n"))
+
+	if !started {
+		t.Error("Did not recieve STARTED event from script\n")
+	}
+	if !completed {
+		t.Error("Did not recieve COMPLETED event from script\n")
+	}
+	if count < expectedLineCount {
+		t.Errorf("Did not recieve expected number of output lines. Expected: %v Recieved: %v\n", expectedLineCount, count)
+	}
+}


### PR DESCRIPTION
<!-- First time? Take a look at: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/ -->
This PR is in response to https://github.com/ReconfigureIO/platform/issues/303

During local testing fake-batch attempts to pull in the production reco-sdaccel from AWS ECR. This full reco-sdaccel is quite bad for testing, it's accurate but it relies heavily on vivado and takes hours to complete a build. This PR aims to add fake-sdaccel-builder and have fake-batch use that when it's in a development environment. This image is automatically built by docker-compose.
<!-- PR Body. Describe the purpose of the change here. -->

<!-- What feedback do you want from the review? -->

Checklist
=========

- [ ] Thought about testing?
- [x] Is the intent of the code clear? (use comments judiciously!)
- [ ] Added to RELEASE.md?

<!--

    Have you told everyone that needs to know about this PR?

    Do you need to update global docs?
        https://github.com/ReconfigureIO/internal-docs/wiki/Engineering-Function

    You *are* allowed to delete the contents of this template.
    Please strive to make the intent of your change clear in the PR.

-->
