### PR TITLE
Avoid passing empty instance IDs to DescribeInstanceStatus

### DIFF
--- a/service/deployment/instances.go
+++ b/service/deployment/instances.go
@@ -80,8 +80,17 @@ func (instances *instances) UpdateInstanceStatus(ctx context.Context) error {
 		return nil
 	}
 
+	var possibleEC2Instances []models.Deployment
+	for _, running := range runningdeployments {
+		id := running.InstanceID
+		if id == "" {
+			continue // No instance associated with this.
+		}
+		possibleEC2Instances = append(possibleEC2Instances, running)
+	}
+
 	// get the status of the associated EC2 instances
-	statuses, err := instances.Deploy.DescribeInstanceStatus(ctx, runningdeployments)
+	statuses, err := instances.Deploy.DescribeInstanceStatus(ctx, possibleEC2Instances)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prevent this by building a list of instances which we believe are running and have non-empty instance IDs.

We currently believe that this is part of the root cause of #307.

```
MissingParameter: The request must contain the parameter SpotInstanceRequestId
```

For now we're going to test this in production. We should think about what needs testing and do it before marking the issue as resolved.

Updates #307.