### PR TITLE
Update DEVICE and DEVICE_FULL for AWS HDK v1.4.5

### DIFF
--- a/service/aws/aws.go
+++ b/service/aws/aws.go
@@ -78,11 +78,11 @@ func (s *Service) RunBuild(build models.Build, callbackURL string, reportsURL st
 				},
 				{
 					Name:  aws.String("DEVICE"),
-					Value: aws.String("xilinx_aws-vu9p-f1_4ddr-xpr-2pr_4_0"),
+					Value: aws.String("xilinx_aws-vu9p-f1-04261818_dynamic_5_0"),
 				},
 				{
 					Name:  aws.String("DEVICE_FULL"),
-					Value: aws.String("xilinx:aws-vu9p-f1:4ddr-xpr-2pr:4.0"),
+					Value: aws.String("xilinx_aws-vu9p-f1-04261818_dynamic_5_0"),
 				},
 				{
 					Name:  aws.String("OUTPUT_URL"),


### PR DESCRIPTION
These environment variables should go away and be subsumed into the
'provide an environment' part of the process. But in the meantime, they
need to have the correct values.

See also https://github.com/ReconfigureIO/reco-sdaccel/pull/240.

Checklist
=========

- [x] Is the intent of the code clear? (use comments judiciously!)
- [ ] Thought about testing?

Testing: hmm. Not totally sure how to test this. I guess the way to do
it would be to deploy to staging, and test it there.